### PR TITLE
Install newest version of cmake.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: 'neovim/neovim'
+      - uses: Homebrew/actions/setup-homebrew@master
       - run: |
          apt-get update
-         apt-get install -y build-essential cmake curl gettext ninja-build unzip
+         apt-get install -y build-essential curl gettext ninja-build unzip
+         brew install cmake
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: |
           echo 'NVIM_BUILD_TYPE=Release' >> $GITHUB_ENV


### PR DESCRIPTION
A newer version of cmake is needed to build neovim.
