### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+env:
+  BIN_DIR: ${{ github.workspace }}/bin
+  MINIMUM_CMAKE_VERSION: '3.13'
+
 # Build on the oldest supported images, so we have broader compatibility
 # Build with gcc-10 to prevent triggering #14150 (default is still gcc-9 on 20.04)
 jobs:
@@ -39,11 +43,30 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: 'neovim/neovim'
-      - uses: Homebrew/actions/setup-homebrew@master
       - run: |
          apt-get update
          apt-get install -y build-essential curl gettext ninja-build unzip
-         brew install cmake
+
+      - name: Add "$BIN_DIR" to path
+        run: echo "$BIN_DIR" >> $GITHUB_PATH
+
+      # TODO(dundargoc): this is very hacky. We only need to install cmake version
+      # that is at least the minimum cmake version, but for some reason the
+      # cmake releases didn't work as described.
+      - name: Install cmake
+        run: |
+         apt-get install -y cmake # Install cmake only for cpack, the cmake version itself is too old
+          curl --retry 5 --silent --show-error --fail -o /tmp/cmake-installer.sh "https://cmake.org/files/v${MINIMUM_CMAKE_VERSION}/cmake-${MINIMUM_CMAKE_VERSION}.0-Linux-x86_64.sh"
+          mkdir -p "$BIN_DIR" /opt/cmake-custom
+          chmod a+x /tmp/cmake-installer.sh
+          /tmp/cmake-installer.sh --prefix=/opt/cmake-custom --skip-license
+          ln -sfn /opt/cmake-custom/bin/cmake "$BIN_DIR/cmake"
+          cmake_version="$(cmake --version | head -1)"
+          echo "$cmake_version" | grep -qF "cmake version $MINIMUM_CMAKE_VERSION.0" || {
+            echo "Unexpected CMake version: $cmake_version"
+            exit 1
+          }
+
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: |
           echo 'NVIM_BUILD_TYPE=Release' >> $GITHUB_ENV


### PR DESCRIPTION
The PPA for cmake didn't seem to work, so we manually install cmake
instead. Install `cmake` from apt but only to use `cpack` since it
doesn't need to be 3.13 in order to work.
