### PR TITLE
ci: downgrade runner version ubuntu-latest to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ env:
 # Build with zig cc so we can target glibc 2.17, so we have broader compatibility
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.build.outputs.version }}
     steps:


### PR DESCRIPTION
This is a temporary workaround for an appimage problem that only occurs
on ubuntu-24.04.

Problem:

- ubuntu-24.04 added the appimagecli validation tool
- our appimage XML fails the validation with the following message:
```
[appimage/stderr] AppStream upstream metadata found in usr/share/metainfo/nvim.appdata.xml
[appimage/stdout] nvim.appdata.xml
[appimage/stdout]   I: io.neovim.nvim:~: developer-info-missing
[appimage/stdout]   W: io.neovim.nvim:~: metainfo-filename-cid-mismatch
[appimage/stdout] 
[appimage/stderr] Failed to validate AppStream information with appstreamcli
[appimage/stdout] ✘ Validation failed: warnings: 1, infos: 1
[appimage/stdout] run_external: subprocess exited with status 3ERROR: Failed to run plugin: appimage (exit code: 1) 
```
- this makes genappimage.sh fail (silently)
- Related issue: https://github.com/AppImage/AppImageKit/issues/603

Solution:
- stick to ubuntu-22.04 for now

Potential solutions in the future:
- manually uninstall appimagecli
- actually fix our AppStream metadata