### PR TITLE
feat: Add arm64 builds

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -25,3 +25,26 @@ ${NVIM_VERSION}
 1. Download **nvim-linux-x86_64.deb**
 2. Install the package using `sudo apt install ./nvim-linux-x86_64.deb`
 3. Run `nvim`
+
+### Linux (arm64)
+#### AppImage
+
+1. Download **nvim-linux-arm64.appimage**
+2. Run `chmod u+x nvim-linux-arm64.appimage && ./nvim-linux-arm64.appimage`
+   - If your system does not have FUSE you can [extract the appimage](https://github.com/AppImage/AppImageKit/wiki/FUSE#type-2-appimage):
+     ```
+     ./nvim-linux-arm64.appimage --appimage-extract
+     ./squashfs-root/usr/bin/nvim
+     ```
+
+#### Tarball
+
+1. Download **nvim-linux-arm64.tar.gz**
+2. Extract: `tar xzvf nvim-linux-arm64.tar.gz`
+3. Run `./nvim-linux-arm64/bin/nvim`
+
+4. #### Debian Package
+
+1. Download **nvim-linux-arm64.deb**
+2. Install the package using `sudo apt install ./nvim-linux-x86_64.deb`
+3. Run `nvim`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,17 @@ env:
 # Build with zig cc so we can target glibc 2.17, so we have broader compatibility
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ ubuntu-22.04, ubuntu-22.04-arm ]
+        include:
+          - runner: ubuntu-22.04
+            arch: x86_64
+          - runner: ubuntu-22.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.runner }}
     outputs:
       version: ${{ steps.build.outputs.version }}
     env:
@@ -79,18 +89,18 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: appimage
+          name: nvim-appimage-${{ matrix.arch }}
           path: |
-            build/bin/nvim-linux-x86_64.appimage
-            build/bin/nvim-linux-x86_64.appimage.zsync
+            build/bin/nvim-linux-${{ matrix.arch }}.appimage
+            build/bin/nvim-linux-${{ matrix.arch }}.appimage.zsync
           retention-days: 1
 
       - uses: actions/upload-artifact@v4
         with:
-          name: nvim-linux64
+          name: nvim-linux-${{ matrix.arch }}
           path: |
-            build/nvim-linux-x86_64.tar.gz
-            build/nvim-linux-x86_64.deb
+            build/nvim-linux-${{ matrix.arch }}.tar.gz
+            build/nvim-linux-${{ matrix.arch }}.deb
           retention-days: 1
 
       - name: Export version
@@ -152,7 +162,7 @@ jobs:
               --notes-file "$RUNNER_TEMP/notes.md" \
               --title "$SUBJECT" \
               --target $GITHUB_SHA \
-              nvim-linux64/* appimage/*
+              nvim-linux-x86_64/* nvim-linux-arm64/* nvim-appimage-x86_64/* nvim-appimage-arm64/*
           fi
 
           gh release delete $TAG_NAME --yes || true
@@ -160,4 +170,4 @@ jobs:
               --notes-file "$RUNNER_TEMP/notes.md" \
               --title "$SUBJECT" \
               --target $GITHUB_SHA \
-              nvim-linux64/* appimage/*
+              nvim-linux-x86_64/* nvim-linux-arm64/* nvim-appimage-x86_64/* nvim-appimage-arm64/*


### PR DESCRIPTION
I was doing some work on some of my personal setup automations and noticed that neovim/neovim is now building arm64 binaries. Trying to use them led me to discover that the glibc version used for 0.10.4 didn't work on Debian 12, and that this repository wasn't building for arm64. It seemed like a simple enough change to fix this up, so I did so.

I will note that in the process of finishing up work on this, I grabbed one of the nightly builds, and those do seem to work on Debian 12 - so this might be less necessary than I realized going forward. Still, it seems like it might be handy for somebody and feels like a simple enough change overall, so I figured it was worth submitting the PR.